### PR TITLE
fix: correct expression blending

### DIFF
--- a/src/cubism2/Live2DExpression.ts
+++ b/src/cubism2/Live2DExpression.ts
@@ -33,15 +33,18 @@ export class Live2DExpression extends AMotion {
 
     /** @override */
     updateParamExe(model: Live2DModelWebGL, time: number, weight: number, motionQueueEnt: unknown) {
-        // if (weight - 1 < 0.0001) {
-        //     this.params.forEach((param) => {
-        //         model.setParamFloat(param.id, param.val);
-        //     });
-        // } else {
-            this.params.forEach((param) => {
-                let p = model.getParamFloat(param.id);
-                model.setParamFloat(param.id, param.val * weight + p * (1-weight));
-            });
-        // }
+        this.params.forEach(param => {
+            switch (param.calc) {
+                case "set":
+                    model.setParamFloat(param.id, param.val, weight);
+                    break;
+                case "add":
+                    model.addToParamFloat(param.id, param.val * weight);
+                    break;
+                case "mult":
+                    model.multParamFloat(param.id, param.val, weight);
+                    break;
+            }
+        });
     }
 }


### PR DESCRIPTION
# 介绍
修复表情混合

之前很早就有人说过 webgal 的表情混合怪怪的, 溯源发现是 pixi-live2d-display 的问题
原本这部分的代码是原作者从他的另一个项目 nep-live2d 搬过来的, 是对海王星模型的特殊处理, 现回滚代码