### PR TITLE
feat: set blink param

### DIFF
--- a/src/cubism-common/InternalModel.ts
+++ b/src/cubism-common/InternalModel.ts
@@ -38,6 +38,25 @@ export interface Bounds {
     height: number;
 }
 
+/**
+ * 眨眼参数，毫秒
+ */
+export interface BlinkParam{
+    blinkInterval: number;          // 眨眼间隔
+    blinkIntervalRandom: number;    // 眨眼间隔随机范围
+    closingDuration: number;        // 闭眼
+    closedDuration: number;         // 保持闭眼
+    openingDuration: number;        // 睁眼
+}
+
+export const baseBlinkParam: BlinkParam = {
+    blinkInterval: 24 * 60 * 60 * 1000, // 24小时
+    blinkIntervalRandom: 1000,
+    closingDuration: 100,
+    closedDuration: 50,
+    openingDuration: 150,
+};
+
 export interface InternalModelOptions extends MotionManagerOptions {}
 
 const tempBounds: Bounds = { x: 0, y: 0, width: 0, height: 0 };
@@ -320,4 +339,6 @@ export abstract class InternalModel extends EventEmitter {
      * Draws the model.
      */
     abstract draw(gl: WebGLRenderingContext): void;
+
+    abstract setBlinkParam(blinkParam: BlinkParam): void;
 }

--- a/src/cubism2/Cubism2InternalModel.ts
+++ b/src/cubism2/Cubism2InternalModel.ts
@@ -1,5 +1,5 @@
 import { InternalModelOptions } from '@/cubism-common';
-import { CommonHitArea, CommonLayout, InternalModel } from '@/cubism-common/InternalModel';
+import { baseBlinkParam, BlinkParam, CommonHitArea, CommonLayout, InternalModel } from '@/cubism-common/InternalModel';
 import { Cubism2ModelSettings } from './Cubism2ModelSettings';
 import { Cubism2MotionManager } from './Cubism2MotionManager';
 import { Live2DEyeBlink } from './Live2DEyeBlink';
@@ -103,6 +103,8 @@ export class Cubism2InternalModel extends InternalModel {
 
             drawParam.gl.viewport(...this.viewport);
         };
+
+        this.setBlinkParam(baseBlinkParam)
     }
 
     protected getSize(): [number, number] {
@@ -278,5 +280,22 @@ export class Cubism2InternalModel extends InternalModel {
 
         // cubism2 core has a super dumb memory management so there's basically nothing much to do to release the model
         (this as Partial<this>).coreModel = undefined;
+    }
+
+    setBlinkParam(blinkParam: BlinkParam): void {
+        if (!this.eyeBlink) {
+            return;
+        }
+
+        try {
+            this.eyeBlink.blinkInterval = blinkParam.blinkInterval;
+            this.eyeBlink.blinkIntervalRandom = blinkParam.blinkIntervalRandom;
+            this.eyeBlink.closingDuration = blinkParam.closingDuration;
+            this.eyeBlink.closedDuration = blinkParam.closedDuration;
+            this.eyeBlink.openingDuration = blinkParam.openingDuration;
+            this.eyeBlink.recalculateBlinkInterval();
+        } catch (error) {
+            console.error('Failed to set blink parameters:', error);
+        }
     }
 }

--- a/src/cubism2/Live2DEyeBlink.ts
+++ b/src/cubism2/Live2DEyeBlink.ts
@@ -12,6 +12,7 @@ export class Live2DEyeBlink {
     rightParam: number;
 
     blinkInterval: DOMHighResTimeStamp = 4000;
+    blinkIntervalRandom: DOMHighResTimeStamp = 1000;
     closingDuration: DOMHighResTimeStamp = 100;
     closedDuration: DOMHighResTimeStamp = 50;
     openingDuration: DOMHighResTimeStamp = 150;
@@ -24,12 +25,23 @@ export class Live2DEyeBlink {
     constructor(readonly coreModel: Live2DModelWebGL) {
         this.leftParam = coreModel.getParamIndex('PARAM_EYE_L_OPEN');
         this.rightParam = coreModel.getParamIndex('PARAM_EYE_R_OPEN');
+        this.recalculateBlinkInterval();
     }
 
     setEyeParams(value: number) {
         this.eyeParamValue = clamp(value, 0, 1);
         this.coreModel.multParamFloat(this.leftParam, this.eyeParamValue);
         this.coreModel.multParamFloat(this.rightParam, this.eyeParamValue);
+    }
+
+    /**
+     * 计算新的眨眼间隔，包括随机值
+     */
+    recalculateBlinkInterval() {
+        let newBlinkInterval = this.blinkInterval;
+        newBlinkInterval += rand(-1, 1) * this.blinkIntervalRandom;
+        newBlinkInterval = Math.max(newBlinkInterval, 0);
+        this.nextBlinkTimeLeft = newBlinkInterval;
     }
 
     update(dt: DOMHighResTimeStamp) {
@@ -39,12 +51,7 @@ export class Live2DEyeBlink {
 
                 if (this.nextBlinkTimeLeft < 0) {
                     this.eyeState = EyeState.Closing;
-                    this.nextBlinkTimeLeft =
-                        this.blinkInterval +
-                        this.closingDuration +
-                        this.closedDuration +
-                        this.openingDuration +
-                        rand(0, 2000);
+                    this.recalculateBlinkInterval();
                 }
                 break;
 

--- a/src/cubism4/Cubism4InternalModel.ts
+++ b/src/cubism4/Cubism4InternalModel.ts
@@ -1,5 +1,5 @@
 import { InternalModelOptions } from '@/cubism-common';
-import { CommonHitArea, CommonLayout, InternalModel } from '@/cubism-common/InternalModel';
+import { baseBlinkParam, BlinkParam, CommonHitArea, CommonLayout, InternalModel } from '@/cubism-common/InternalModel';
 import { Cubism4ModelSettings } from '@/cubism4/Cubism4ModelSettings';
 import { Cubism4MotionManager } from '@/cubism4/Cubism4MotionManager';
 import {
@@ -12,7 +12,7 @@ import {
     ParamEyeBallY,
 } from '@cubism/cubismdefaultparameterid';
 import { BreathParameterData, CubismBreath } from '@cubism/effect/cubismbreath';
-import { CubismEyeBlink } from '@cubism/effect/cubismeyeblink';
+import { CubismEyeBlink } from './cubismeyeblink';
 import { CubismPose } from '@cubism/effect/cubismpose';
 import { CubismMatrix44 } from '@cubism/math/cubismmatrix44';
 import { CubismModel } from '@cubism/model/cubismmodel';
@@ -92,6 +92,8 @@ export class Cubism4InternalModel extends InternalModel {
 
         this.renderer.initialize(this.coreModel);
         this.renderer.setIsPremultipliedAlpha(true);
+
+        this.setBlinkParam(baseBlinkParam)
     }
 
     protected getSize(): [number, number] {
@@ -268,5 +270,22 @@ export class Cubism4InternalModel extends InternalModel {
 
         (this as Partial<this>).renderer = undefined;
         (this as Partial<this>).coreModel = undefined;
+    }
+
+    setBlinkParam(blinkParam: BlinkParam): void {
+        if (!this.eyeBlink) {
+            return;
+        }
+
+        try {
+            this.eyeBlink._blinkingIntervalSeconds = blinkParam.blinkInterval / 1000;
+            this.eyeBlink._blinkingIntervalRandomSeconds = blinkParam.blinkIntervalRandom / 1000;
+            this.eyeBlink._closingSeconds = blinkParam.closingDuration / 1000;
+            this.eyeBlink._closedSeconds = blinkParam.closedDuration / 1000;
+            this.eyeBlink._openingSeconds = blinkParam.openingDuration / 1000;
+            this.eyeBlink._nextBlinkingTime = this.eyeBlink.determinNextBlinkingTiming();
+        } catch (error) {
+            console.error('Failed to set blink parameters:', error);
+        }
     }
 }

--- a/src/cubism4/cubismeyeblink.ts
+++ b/src/cubism4/cubismeyeblink.ts
@@ -1,0 +1,213 @@
+/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+import { CubismModel } from '@cubism/model/cubismmodel';
+import { CubismModelSettingsJson } from '@cubism/settings/cubismmodelsettingsjson';
+
+/**
+ * 自動まばたき機能
+ *
+ * 自動まばたき機能を提供する。
+ */
+export class CubismEyeBlink {
+  /**
+   * インスタンスを作成する
+   * @param modelSetting モデルの設定情報
+   * @return 作成されたインスタンス
+   * @note 引数がNULLの場合、パラメータIDが設定されていない空のインスタンスを作成する。
+   */
+  public static create(
+    modelSetting: CubismModelSettingsJson,
+  ): CubismEyeBlink {
+    return new CubismEyeBlink(modelSetting);
+  }
+
+  /**
+   * まばたきの間隔の設定
+   * @param blinkingInterval まばたきの間隔の時間[秒]
+   */
+  public setBlinkingInterval(blinkingInterval: number): void {
+    this._blinkingIntervalSeconds = blinkingInterval;
+  }
+
+  /**
+   * まばたきのモーションの詳細設定
+   * @param closing   まぶたを閉じる動作の所要時間[秒]
+   * @param closed    まぶたを閉じている動作の所要時間[秒]
+   * @param opening   まぶたを開く動作の所要時間[秒]
+   */
+  public setBlinkingSetting(
+    closing: number,
+    closed: number,
+    opening: number,
+  ): void {
+    this._closingSeconds = closing;
+    this._closedSeconds = closed;
+    this._openingSeconds = opening;
+  }
+
+  /**
+   * まばたきさせるパラメータIDのリストの設定
+   * @param parameterIds パラメータのIDのリスト
+   */
+  public setParameterIds(parameterIds: string[]): void {
+    this._parameterIds = parameterIds;
+  }
+
+  /**
+   * まばたきさせるパラメータIDのリストの取得
+   * @return パラメータIDのリスト
+   */
+  public getParameterIds(): string[] {
+    return this._parameterIds;
+  }
+
+  /**
+   * モデルのパラメータの更新
+   * @param model 対象のモデル
+   * @param deltaTimeSeconds デルタ時間[秒]
+   */
+  public updateParameters(
+    model: CubismModel,
+    deltaTimeSeconds: number,
+  ): void {
+    this._userTimeSeconds += deltaTimeSeconds;
+    let parameterValue: number;
+    let t = 0.0;
+
+    switch (this._blinkingState) {
+      case EyeState.EyeState_Closing:
+        t = this._userTimeSeconds / this._closingSeconds;
+
+        if (t >= 1.0) {
+          t = 1.0;
+          this._blinkingState = EyeState.EyeState_Closed;
+          this._userTimeSeconds = 0.0;
+        }
+
+        parameterValue = 1.0 - t;
+
+        break;
+      case EyeState.EyeState_Closed:
+        t = this._userTimeSeconds / this._closedSeconds;
+
+        if (t >= 1.0) {
+          this._blinkingState = EyeState.EyeState_Opening;
+          this._userTimeSeconds = 0.0;
+        }
+
+        parameterValue = 0.0;
+
+        break;
+      case EyeState.EyeState_Opening:
+        t = this._userTimeSeconds / this._openingSeconds;
+
+        if (t >= 1.0) {
+          t = 1.0;
+          this._blinkingState = EyeState.EyeState_Interval;
+          this._nextBlinkingTime = this.determinNextBlinkingTiming();
+          this._userTimeSeconds = 0.0;
+        }
+
+        parameterValue = t;
+
+        break;
+      case EyeState.EyeState_Interval:
+        if (this._nextBlinkingTime < this._userTimeSeconds) {
+          this._blinkingState = EyeState.EyeState_Closing;
+          this._userTimeSeconds = 0.0;
+        }
+
+        parameterValue = 1.0;
+
+        break;
+      case EyeState.EyeState_First:
+      default:
+        this._blinkingState = EyeState.EyeState_Interval;
+        this._nextBlinkingTime = this.determinNextBlinkingTiming();
+
+        parameterValue = 1.0;
+        break;
+    }
+
+    if (!CubismEyeBlink.CloseIfZero) {
+      parameterValue = -parameterValue;
+    }
+
+    for (let i = 0; i < this._parameterIds.length; ++i) {
+      const paramId = this._parameterIds[i];
+      if (typeof paramId === 'string') {
+        model.setParameterValueById(paramId, parameterValue);
+      }
+    }
+  }
+
+  /**
+   * コンストラクタ
+   * @param modelSetting モデルの設定情報
+   */
+  public constructor(modelSetting: CubismModelSettingsJson) {
+    this._blinkingState = EyeState.EyeState_First;
+    this._nextBlinkingTime = 0.0;
+    this._stateStartTimeSeconds = 0.0;
+    this._blinkingIntervalSeconds = 4.0;
+    this._blinkingIntervalRandomSeconds = 1.0;
+    this._closingSeconds = 0.1;
+    this._closedSeconds = 0.05;
+    this._openingSeconds = 0.15;
+    this._userTimeSeconds = 0.0;
+    this._parameterIds = [];
+
+    if (modelSetting == null) {
+      return;
+    }
+
+    this._parameterIds = modelSetting.getEyeBlinkParameters()?.slice() ?? this._parameterIds;
+  }
+
+  /**
+   * 次の瞬きのタイミングの決定
+   *
+   * @return 次のまばたきを行う時刻[秒]
+   */
+  public determinNextBlinkingTiming(): number {
+    let newBlinkInterval = this._blinkingIntervalSeconds;
+    newBlinkInterval +=
+      (Math.random() * 2.0 - 1.0) * this._blinkingIntervalRandomSeconds;
+    newBlinkInterval = Math.max(newBlinkInterval, 0);
+    return newBlinkInterval;
+  }
+
+  _blinkingState: number; // 現在の状態
+  _parameterIds: string[]; // 操作対象のパラメータのIDのリスト
+  _nextBlinkingTime: number; // 次のまばたきの時刻[秒]
+  _stateStartTimeSeconds: number; // 現在の状態が開始した時刻[秒]
+  _blinkingIntervalSeconds: number; // まばたきの間隔[秒]
+  _blinkingIntervalRandomSeconds: number; // まばたきの間隔のランダム値[秒]
+  _closingSeconds: number; // まぶたを閉じる動作の所要時間[秒]
+  _closedSeconds: number; // まぶたを閉じている動作の所要時間[秒]
+  _openingSeconds: number; // まぶたを開く動作の所要時間[秒]
+  _userTimeSeconds: number; // デルタ時間の積算値[秒]
+
+  /**
+   * IDで指定された目のパラメータが、0のときに閉じるなら true 、1の時に閉じるなら false 。
+   */
+  static readonly CloseIfZero: boolean = true;
+}
+
+/**
+ * まばたきの状態
+ *
+ * まばたきの状態を表す列挙型
+ */
+export enum EyeState {
+  EyeState_First = 0, // 初期状態
+  EyeState_Interval, // まばたきしていない状態
+  EyeState_Closing, // まぶたが閉じていく途中の状態
+  EyeState_Closed, // まぶたが閉じている状態
+  EyeState_Opening // まぶたが開いていく途中の状態
+}


### PR DESCRIPTION
# 介绍
为 cubism2InternalModel 和 cubism4InternalModel 增添一个统一的设置眨眼参数的函数

# 主要更改
- `InternalModel` 新增抽象函数 `setBlinkParam`，便于统一设置眨眼相关参数
- 从 `cubism` 中复制了一份 `CubismEyeBlink` 的类到 `cubism4` 目录下。因为这个类在 `cubism` 这个子模组里，用 git 不是很好记录，所以复制一份出来自己用，并做了一点修改
- 赋予 cubism2InternalModel 和 cubism4InternalModel 相同的初始眨眼参数，并且眨眼间隔默认为一天，意为不眨眼
- 部分统一 cubism2InternalModel 和 cubism4InternalModel 的眨眼行为，但还是有一点点差别，我觉得问题不大（