### PR TITLE
fix: cubism 4 blink behavior

### DIFF
--- a/src/cubism4/cubismeyeblink.ts
+++ b/src/cubism4/cubismeyeblink.ts
@@ -141,7 +141,7 @@ export class CubismEyeBlink {
     for (let i = 0; i < this._parameterIds.length; ++i) {
       const paramId = this._parameterIds[i];
       if (typeof paramId === 'string') {
-        model.setParameterValueById(paramId, parameterValue);
+        model.multiplyParameterValueById(paramId, parameterValue);
       }
     }
   }


### PR DESCRIPTION
# 介绍

修复 Cubism 4 眨眼时未正确混合眨眼参数

此 PR 前, 使用 model3 模型播放带有眼睛参数的动作, 比如半睁眼那种, blink 会强制将其拉到 1 再开始播放 0~1 的动画

#5 上次改了 cubism 2 那边的, 忘了看一眼 cubism 4 这边
