### PR TITLE
fix: use Cubism2 standard keys (init_param, init_parts_visible, val) with legacy fallback

### DIFF
--- a/src/cubism2/Cubism2InternalModel.ts
+++ b/src/cubism2/Cubism2InternalModel.ts
@@ -70,10 +70,12 @@ export class Cubism2InternalModel extends InternalModel {
         super.init();
 
         if (this.settings.initParams) {
-            this.settings.initParams.forEach(({ id, value }) => this.coreModel.setParamFloat(id, value));
+            // Prefer standard field `val`, fallback to legacy `value`
+            this.settings.initParams.forEach(({ id, val, value }) => this.coreModel.setParamFloat(id, val ?? value!));
         }
         if (this.settings.initOpacities) {
-            this.settings.initOpacities.forEach(({ id, value }) => this.coreModel.setPartsOpacity(id, value));
+            // Prefer standard field `val`, fallback to legacy `value`
+            this.settings.initOpacities.forEach(({ id, val, value }) => this.coreModel.setPartsOpacity(id, val ?? value!));
         }
 
         this.coreModel.saveParam();

--- a/src/cubism2/Cubism2ModelSettings.ts
+++ b/src/cubism2/Cubism2ModelSettings.ts
@@ -64,8 +64,17 @@ export class Cubism2ModelSettings extends ModelSettings {
 
         copyArray('object', json, this, 'hit_areas', 'hitAreas');
         copyArray('object', json, this, 'expressions', 'expressions');
-        copyArray('object', json, this, 'init_params', 'initParams');
-        copyArray('object', json, this, 'init_opacities', 'initOpacities');
+        // Prefer standard key `init_param`, fallback to legacy `init_params`
+        copyArray('object', json, this, 'init_param', 'initParams');
+        if (!this.initParams) {
+            copyArray('object', json, this, 'init_params', 'initParams');
+        }
+
+        // Prefer standard key `init_parts_visible`, fallback to legacy `init_opacities`
+        copyArray('object', json, this, 'init_parts_visible', 'initOpacities');
+        if (!this.initOpacities) {
+            copyArray('object', json, this, 'init_opacities', 'initOpacities');
+        }
     }
 
     replaceFiles(replace: (file: string, path: string) => string) {

--- a/src/types/Cubism2Spec.d.ts
+++ b/src/types/Cubism2Spec.d.ts
@@ -11,7 +11,11 @@ export namespace Cubism2Spec {
         // metadata
         layout?: Layout;
         hit_areas?: HitArea[];
+        init_param?: InitParam[];
+        /** Legacy alias for `init_param` */
         init_params?: InitParam[];
+        init_parts_visible?: InitOpacity[];
+        /** Legacy alias for `init_parts_visible` */
         init_opacities?: InitOpacity[];
 
         // motions
@@ -60,12 +64,16 @@ export namespace Cubism2Spec {
 
     interface InitParam {
         id: string;
-        value: number
+        val?: number;
+        /** Legacy alias for `val`. */
+        value?: number
     }
 
     interface InitOpacity {
         id: string;
-        value: number
+        val?: number;
+        /** Legacy alias for `val`. */
+        value?: number
     }
 
     interface ExpressionJSON {


### PR DESCRIPTION
虽然无法查找到Live2D Cubism 2的model.json的官方定义，但根据github上其他相关项目，特别是 [dylanNew/live2d](https://github.com/dylanNew/live2d) 中的相关代码判断，Cubism 2中原始的参数初始化和部件透明度初始化设置应当分别使用的是`init_param`和`init_parts_visible`，而非PLD中使用的`init_params`和`init_opacities`，且其中的值字段也应该是`val`而非`value`。

添加了对两个疑似的标准字段的支持，且在缺失时回滚使用PLD原本的字段，以保证向前兼容性。